### PR TITLE
Support X_FORWARDED_FOR header to get IP

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -13,8 +13,15 @@ class SessionMiddleware(object):
     def process_request(self, request):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
+        
+        x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(',')[0]
+        else:
+            ip = request.META.get('REMOTE_ADDR', '')
+            
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', ''),
+            ip=ip,
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )


### PR DESCRIPTION
My environment doesn't forward REMOTE_ADDR (it's always localhost) but X-Forwarded-For is accurate. This patch allows both.
