### PR TITLE
Fixed bug in updating last_activity

### DIFF
--- a/user_sessions/backends/db.py
+++ b/user_sessions/backends/db.py
@@ -29,9 +29,8 @@ class SessionStore(SessionBase):
                 expire_date__gt=timezone.now()
             )
             self.user_id = s.user_id
-            # do not overwrite user_agent/ip, as those might have been updated
-            if self.user_agent != s.user_agent or self.ip != s.ip:
-                self.modified = True
+            # mark as modified so the last_activity update will be saved
+            self.modified = True
             return self.decode(s.session_data)
         except (Session.DoesNotExist, SuspiciousOperation) as e:
             if isinstance(e, SuspiciousOperation):


### PR DESCRIPTION
Since the backend only updated the session if it was (marked as) modified, instead of for every page view, the last_activity field doesn't always reflect the actual time of last activity. This change makes the backed always update the session in the database, though possibly, of course, at the cost of an extra query.
