### PR TITLE
Added an optional USER_SESSIONS_USER_TO_FIELD setting

### DIFF
--- a/user_sessions/models.py
+++ b/user_sessions/models.py
@@ -32,7 +32,7 @@ class Session(models.Model):
         return SessionStore(None, None).decode(self.session_data)
 
     user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
-                             getattr(settings, 'USER_SESSIONS_USER_TO_FIELD', None),
+                             to_field=getattr(settings, 'USER_SESSIONS_USER_TO_FIELD', None),
                              null=True)
     user_agent = models.CharField(max_length=200)
     last_activity = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
Allowing configuration of `Session.user.to_field`.

My use case: I have a field `uuid` on my `Account` model which is the actual field I'd like to reference. I can't make that field primary yet since it will break other parts of Django or other packages that expect `Account.pk` to be an integer.
