### PR TITLE
Real IP if client behind load balancer

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -13,8 +13,12 @@ class SessionMiddleware(object):
     def process_request(self, request):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
+        if 'HTTP_X_FORWARDED_FOR' in request.META:
+            client_ip = request.META.get('HTTP_X_FORWARDED_FOR', '')
+        else:
+            client_ip = request.META.get('REMOTE_ADDR', '')
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', ''),
+            ip=client_ip,
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )


### PR DESCRIPTION
Hi,

If the webserver is behind a load balancer, for example, in AWS with an elastic load balancer, the REMOTE_ADDR will be the ELB ip, not the client ip.

Best regards,

Alberto
