### PR TITLE
add: same site cookie setting

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -68,6 +68,10 @@ class MiddlewareTest(TestCase):
         session = Session.objects.get(
             pk=self.client.cookies[settings.SESSION_COOKIE_NAME].value
         )
+        self.assertEqual(
+            self.client.cookies[settings.SESSION_COOKIE_NAME]["samesite"],
+            settings.SESSION_COOKIE_SAMESITE,
+        )
         self.assertEqual(user, session.user)
 
     def test_long_ua(self):

--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -62,5 +62,7 @@ class SessionMiddleware(MiddlewareMixin):
                         domain=settings.SESSION_COOKIE_DOMAIN,
                         path=settings.SESSION_COOKIE_PATH,
                         secure=settings.SESSION_COOKIE_SECURE or None,
-                        httponly=settings.SESSION_COOKIE_HTTPONLY or None)
+                        httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+                        samesite=settings.SESSION_COOKIE_SAMESITE,
+                    )
         return response


### PR DESCRIPTION
Adds support for Django's `settings.SESSION_COOKIE_SAMESITE`

closes: https://github.com/jazzband/django-user-sessions/issues/112
rel: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE
rel: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies

I was also thinking we could inherit from Django's SessionAuthentication and override a method instead of having to copy over changes.

Something like:


```python
class SessionMiddleware(DjangoSessionMiddleware):
    def process_request(self, request):
        session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
        request.session = self.SessionStore(
            ip=request.META.get("REMOTE_ADDR", ""),
            user_agent=request.META.get("HTTP_USER_AGENT", ""),
            session_key=session_key,
        )
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
