### PR TITLE
Rename OS X to macOS

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,24 +23,24 @@ You could logout the user everywhere::
 
 Generic views
 -------------
-There are two views included with this application, 
-:class:`~user_sessions.views.SessionListView` and 
+There are two views included with this application,
+:class:`~user_sessions.views.SessionListView` and
 :class:`~user_sessions.views.SessionDeleteView`. Using this views you have a
-simple, but effective, user session management that even looks great out of 
+simple, but effective, user session management that even looks great out of
 the box:
 
 .. image:: _static/custom-view.png
 
 Template tags
 ~~~~~~~~~~~~~
-Two template tags are included 
+Two template tags are included
 :meth:`~user_sessions.templatetags.user_sessions.device` and
 :meth:`~user_sessions.templatetags.user_sessions.location`. These can be used
 for respectively humanizing the user agent string and showing an approximate
 location of the IP address::
 
     {% load user_sessions %}
-    {{ session.user_agent|device }} -> Safari on OS X
+    {{ session.user_agent|device }} -> Safari on macOS
     {{ session.ip|location }}       -> Zwolle, The Netherlands
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -375,7 +375,7 @@ class DeviceTemplateFilterTest(TestCase):
                    'Mobile/11A465 Safari/9537.53')
         )
         self.assertEqual(
-            'Safari on OS X',
+            'Safari on macOS',
             device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) '
                    'AppleWebKit/536.26.17 (KHTML, like Gecko) Version/6.0.2 '
                    'Safari/536.26.17')

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -26,7 +26,7 @@ DEVICES = (
     (re.compile('Mac OS X 10[._]11'), _('OS X El Capitan')),
     (re.compile('Mac OS X 10[._]12'), _('macOS Sierra')),
     (re.compile('Mac OS X 10[._]13'), _('macOS High Sierra')),
-    (re.compile('Mac OS X'), _('OS X')),
+    (re.compile('Mac OS X'), _('macOS')),
     (re.compile('NT 5.1'), _('Windows XP')),
     (re.compile('NT 6.0'), _('Windows Vista')),
     (re.compile('NT 6.1'), _('Windows 7')),
@@ -46,7 +46,7 @@ def device(value):
 
     * Safari on iPhone
     * Chrome on Windows 8.1
-    * Safari on OS X
+    * Safari on macOS
     * Firefox
     * Linux
     * None


### PR DESCRIPTION
## Description
Rename OS X to macOS in django-user-sessions UI.

## Motivation and Context
Since 2016, Apple rebranded 'OS X' to 'macOS'. See also https://en.wikipedia.org/wiki/MacOS#macOS

## Screenshots (if appropriate):
<img width="872" alt="Schermafbeelding 2020-06-22 om 18 06 04" src="https://user-images.githubusercontent.com/659504/85309554-0ee11880-b4b3-11ea-992c-c16a326472c8.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
