### PR TITLE
Add macOS Mojave and Catalina

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -375,6 +375,17 @@ class DeviceTemplateFilterTest(TestCase):
                    'Mobile/11A465 Safari/9537.53')
         )
         self.assertEqual(
+            'Chrome on macOS Mojave',
+            device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) '
+                'Chrome/85.0.4178.0 Safari/537.36')
+        )
+        self.assertEqual(
+            'Firefox on macOS Catalina',
+            device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) '
+                'Gecko/20100101 Firefox/77.0')
+        )
+        self.assertEqual(
             'Safari on OS X',
             device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) '
                    'AppleWebKit/536.26.17 (KHTML, like Gecko) Version/6.0.2 '

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -26,6 +26,8 @@ DEVICES = (
     (re.compile('Mac OS X 10[._]11'), _('OS X El Capitan')),
     (re.compile('Mac OS X 10[._]12'), _('macOS Sierra')),
     (re.compile('Mac OS X 10[._]13'), _('macOS High Sierra')),
+    (re.compile('Mac OS X 10[._]14'), _('macOS Mojave')),
+    (re.compile('Mac OS X 10[._]15'), _('macOS Catalina')),
     (re.compile('Mac OS X'), _('OS X')),
     (re.compile('NT 5.1'), _('Windows XP')),
     (re.compile('NT 6.0'), _('Windows Vista')),


### PR DESCRIPTION
These were not yet explicitly recognized.

## Description
This adds user agent recognition for the two newest macOS versions.

## Motivation and Context
These were previously not recognized.

## How Has This Been Tested?
I've found user agents for these devices in my server logs and added them as test cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
