### PR TITLE
Add detection for Chromium-based Edge browser

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -428,6 +428,26 @@ class DeviceTemplateFilterTest(TestCase):
                    'Mobile Safari/537.36 Edge/40.15254.369')
         )
 
+    def test_edge_chromium(self):
+        self.assertEquals(
+            'Edge on Windows 10',
+            device('Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                   'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.113 '
+                   'Safari/537.36 Edg/81.0.416.62')
+        )
+        self.assertEquals(
+            'Edge on macOS Catalina',
+            device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) '
+                   'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 '
+                   'Safari/537.36 Edg/85.0.564.51')
+        )
+        self.assertEquals(
+            'Edge on Android',
+            device('Mozilla/5.0 (Linux; Android 11; Pixel 3 XL) '
+                   'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 '
+                   'Mobile Safari/537.36 EdgA/45.07.4.5059')
+        )
+
     def test_firefox_only(self):
         self.assertEqual("Firefox", device("Not a legit OS Firefox/51.0"))
 

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 register = template.Library()
 
 BROWSERS = (
-    (re.compile('Edge'), _('Edge')),
+    (re.compile('Edg'), _('Edge')),
     (re.compile('Chrome'), _('Chrome')),
     (re.compile('Safari'), _('Safari')),
     (re.compile('Firefox'), _('Firefox')),


### PR DESCRIPTION
The Edge browser is now chromium-based and was previously recognized by
django-user-sessions as 'Chrome'.

Its user agent now contains"Edg/79.0.309.43"

ref: https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string

The browser is  also available on macOS and on Android, I've added those user
agent strings to the tests just for fun.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for Chromium based Edge browser
<!--- Describe your changes in detail -->


## How Has This Been Tested?
I've captured user agents from my systems and added them to the unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


By the way, the 