### PR TITLE
Replace deprecated functions to remove deprecation warnings

### DIFF
--- a/user_sessions/admin.py
+++ b/user_sessions/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from user_sessions.templatetags.user_sessions import device, location
 
 from .models import Session

--- a/user_sessions/backends/db.py
+++ b/user_sessions/backends/db.py
@@ -5,7 +5,7 @@ from django.contrib.sessions.backends.base import CreateError, SessionBase
 from django.core.exceptions import SuspiciousOperation
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 class SessionStore(SessionBase):
@@ -39,7 +39,7 @@ class SessionStore(SessionBase):
             if isinstance(e, SuspiciousOperation):
                 logger = logging.getLogger('django.security.%s' %
                                            e.__class__.__name__)
-                logger.warning(force_text(e))
+                logger.warning(force_str(e))
             self.create()
             return {}
 

--- a/user_sessions/models.py
+++ b/user_sessions/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class SessionManager(models.Manager):

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -3,7 +3,7 @@ import warnings
 
 from django import template
 from django.contrib.gis.geoip2 import HAS_GEOIP2
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 register = template.Library()
 


### PR DESCRIPTION
## Description

- Replace ugettext_lazy by gettext_lazy
- Replace force_text with force_str

## Motivation and Context
These functions are deprecated. They are still required on Python 2. Since Python 2 is not supported any more, we can replace them. See #122 

## How Has This Been Tested?
This is a strathforward replace with new function. If tests passes, the functions can be imported, we are good to go.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
