### PR TITLE
Updated support Python and Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 env:
  - DJANGO=2.2
  - DJANGO=3.0
+ - DJANGO=3.1
  - DJANGO=master
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
  - 3.6
  - 3.7
  - 3.8
+ - 3.9
 
 env:
  - DJANGO=2.2
@@ -13,9 +14,6 @@ env:
 
 matrix:
   include:
-    - python: 3.5
-      env: DJANGO=2.2
-
     - python: 3.8
       env: TOXENV=flake8
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ contains the package `django-two-factor-auth`_, but that application is not a
 dependency for this package. Also have a look at the bundled example templates
 and views to see how you can integrate the application into your project.
 
-Compatible with Django 2.2 and 3.0 on Python 3.6, 3.7, 3.8 and 3.9.
+Compatible with Django 2.2, 3,0 and 3.1 on Python 3.6, 3.7, 3.8 and 3.9.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ contains the package `django-two-factor-auth`_, but that application is not a
 dependency for this package. Also have a look at the bundled example templates
 and views to see how you can integrate the application into your project.
 
-Compatible with Django 2.2 and 3.0 on Python 3.5, 3.6, 3.7 and 3.8.
+Compatible with Django 2.2 and 3.0 on Python 3.6, 3.7, 3.8 and 3.9.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -272,4 +272,5 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 from django.conf import settings
+
 settings.configure(DEBUG=False)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,6 @@ flake8
 tox
 tox-pyenv
 detox
-mock
 isort
 
 # Transifex

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,3 @@ known_first_party = two_factor
 line_length = 79
 multi_line_output = 5
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-
-[wheel]
-universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ include_trailing_comma = true
 known_first_party = two_factor
 line_length = 79
 multi_line_output = 5
-not_skip = __init__.py
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [wheel]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='django-user-sessions',
@@ -24,10 +24,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Security',
     ],
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime, timedelta
 from unittest import skipUnless
+from unittest.mock import patch
 
 import django
 from django.conf import settings
@@ -12,6 +13,7 @@ from django.test import TestCase, TransactionTestCase
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
+
 from user_sessions.backends.db import SessionStore
 from user_sessions.models import Session
 from user_sessions.templatetags.user_sessions import device, location
@@ -21,10 +23,6 @@ try:
     from urllib.parse import urlencode
 except ImportError:
     from urllib import urlencode
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
 
 try:
     from django.contrib.gis.geoip2 import GeoIP2
@@ -416,12 +414,12 @@ class DeviceTemplateFilterTest(TestCase):
         )
 
     def test_edge(self):
-        self.assertEquals(
+        self.assertEqual(
             'Edge on Windows 10',
             device('Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, '
                    'like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136')
         )
-        self.assertEquals(
+        self.assertEqual(
             'Edge on Windows Mobile',
             device('Mozilla/5.0 (Windows Mobile 10; Android 8.0.0; Microsoft; Lumia '
                    '950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 '
@@ -429,19 +427,19 @@ class DeviceTemplateFilterTest(TestCase):
         )
 
     def test_edge_chromium(self):
-        self.assertEquals(
+        self.assertEqual(
             'Edge on Windows 10',
             device('Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
                    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.113 '
                    'Safari/537.36 Edg/81.0.416.62')
         )
-        self.assertEquals(
+        self.assertEqual(
             'Edge on macOS Catalina',
             device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) '
                    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 '
                    'Safari/537.36 Edg/85.0.564.51')
         )
-        self.assertEquals(
+        self.assertEqual(
             'Edge on Android',
             device('Mozilla/5.0 (Linux; Android 11; Pixel 3 XL) '
                    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 '
@@ -496,8 +494,10 @@ class ClearsessionsCommandTest(TestCase):
 class MigratesessionsCommandTest(TransactionTestCase):
     @modify_settings(INSTALLED_APPS={'append': 'django.contrib.sessions'})
     def test_migrate_from_login(self):
+        from django.contrib.sessions.backends.db import (
+            SessionStore as DjangoSessionStore,
+        )
         from django.contrib.sessions.models import Session as DjangoSession
-        from django.contrib.sessions.backends.db import SessionStore as DjangoSessionStore
         try:
             call_command('migrate', 'sessions')
             call_command('clearsessions')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,8 @@
-import sys
 from datetime import datetime, timedelta
 from unittest import skipUnless
 from unittest.mock import patch
+from urllib.parse import urlencode
 
-import django
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.models import User
@@ -18,11 +17,6 @@ from user_sessions.backends.db import SessionStore
 from user_sessions.models import Session
 from user_sessions.templatetags.user_sessions import device, location
 from user_sessions.utils.tests import Client
-
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
 
 try:
     from django.contrib.gis.geoip2 import GeoIP2
@@ -375,13 +369,13 @@ class DeviceTemplateFilterTest(TestCase):
         self.assertEqual(
             'Chrome on macOS Mojave',
             device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/85.0.4178.0 Safari/537.36')
+                   'AppleWebKit/537.36 (KHTML, like Gecko) '
+                   'Chrome/85.0.4178.0 Safari/537.36')
         )
         self.assertEqual(
             'Firefox on macOS Catalina',
             device('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) '
-                'Gecko/20100101 Firefox/77.0')
+                   'Gecko/20100101 Firefox/77.0')
         )
         self.assertEqual(
             'Safari on macOS',

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,6 @@
-from django.urls import include, path
 from django.contrib import admin
 from django.http import HttpResponse
+from django.urls import include, path
 
 admin.autodiscover()
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 from django.http import HttpResponse
 
@@ -15,8 +15,8 @@ def modify_session(request):
 
 
 urlpatterns = [
-    url(r'^$', empty),
-    url(r'^modify_session/$', modify_session),
-    url(r'^admin/', admin.site.urls),
-    url(r'', include('user_sessions.urls', namespace='user_sessions')),
+    path('', empty),
+    path('modify_session/', modify_session),
+    path('admin/', admin.site.urls),
+    path('', include('user_sessions.urls', namespace='user_sessions')),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{36,37,38,39}-{dj22,dj30,djmaster},
+    py{36,37,38,39}-{dj22,dj30,dj31,djmaster},
     flake8
 
 [travis]
@@ -12,16 +12,18 @@ unignore_outcomes = True
 DJANGO =
     2.2: dj22
     3.0: dj30
+    3.1: dj31
     master: djmaster
 
 [testenv]
 commands = 
-    coverage run {envbindir}/django-admin.py test -v 2 --pythonpath=./ --settings=tests.settings
+    coverage run {envbindir}/django-admin test -v 2 --pythonpath=./ --settings=tests.settings
     coverage report
 deps =
     coverage
     dj22: Django<2.3
     dj30: Django<3.1
+    dj31: Django<3.2
     djmaster: https://github.com/django/django/archive/master.tar.gz
 ignore_outcome =
     djmaster: True

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{35,36,37,38}-{dj22},
-    py{36,37,38}-{dj30,djmaster},
+    py{36,37,38,39}-{dj22,dj30,djmaster},
     flake8
 
 [travis]

--- a/user_sessions/admin.py
+++ b/user_sessions/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
+
 from user_sessions.templatetags.user_sessions import device, location
 
 from .models import Session

--- a/user_sessions/management/commands/migratesessions.py
+++ b/user_sessions/management/commands/migratesessions.py
@@ -4,6 +4,7 @@ import logging
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
+
 from user_sessions.models import Session as UserSession
 
 logger = logging.getLogger(__name__)

--- a/user_sessions/urls.py
+++ b/user_sessions/urls.py
@@ -6,11 +6,13 @@ from .views import SessionDeleteView, SessionListView
 
 app_name = 'user_sessions'
 urlpatterns = [
-    path('account/sessions/',
+    path(
+        'account/sessions/',
         view=SessionListView.as_view(),
         name='session_list',
     ),
-    path('account/sessions/other/delete/',
+    path(
+        'account/sessions/other/delete/',
         view=SessionDeleteOtherView.as_view(),
         name='session_delete_other',
     ),

--- a/user_sessions/urls.py
+++ b/user_sessions/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+
 from user_sessions.views import SessionDeleteOtherView
 
 from .views import SessionDeleteView, SessionListView

--- a/user_sessions/urls.py
+++ b/user_sessions/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from user_sessions.views import SessionDeleteOtherView
 
@@ -6,18 +6,16 @@ from .views import SessionDeleteView, SessionListView
 
 app_name = 'user_sessions'
 urlpatterns = [
-    url(
-        regex=r'^account/sessions/$',
+    path('account/sessions/',
         view=SessionListView.as_view(),
         name='session_list',
     ),
-    url(
-        regex=r'^account/sessions/other/delete/$',
+    path('account/sessions/other/delete/',
         view=SessionDeleteOtherView.as_view(),
         name='session_delete_other',
     ),
-    url(
-        regex=r'^account/sessions/(?P<pk>\w+)/delete/$',
+    re_path(
+        r'^account/sessions/(?P<pk>\w+)/delete/$',
         view=SessionDeleteView.as_view(),
         name='session_delete',
     ),


### PR DESCRIPTION
## Description
Added support for Python 3.9 and Django 3.1. Support for Python 3.5 has been removed in line with other Jazzband projects. 

## How Has This Been Tested?
Run tox locally, all tests pass. Also tested with warnings to identify and deprecation warnings. Two items highlighted were removal or `url()` and the `django-admin.py` entry point. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
