### PR TITLE
Dropped Python 3.6 and 3.7 when testing Django master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{36,37,38,39}-{dj22,dj30,dj31,djmaster},
+    py{36,37,38,39}-{dj22,dj30,dj31},
+    py{38,39}-{djmaster}
     flake8
 
 [travis]


### PR DESCRIPTION
Django master branch has now [dropped support](https://github.com/django/django/commit/ec0ff406311de88f4e2a135d784363424fe602aa) for Python 3.6 and 3.7. 