### PR TITLE
Bug fix: Make Opera browser recongizable

### DIFF
--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -9,10 +9,10 @@ register = template.Library()
 
 BROWSERS = (
     (re.compile('Edg'), _('Edge')),
+    (re.compile('OPR'), _('Opera')),
     (re.compile('Chrome'), _('Chrome')),
     (re.compile('Safari'), _('Safari')),
     (re.compile('Firefox'), _('Firefox')),
-    (re.compile('Opera'), _('Opera')),
     (re.compile('IE'), _('Internet Explorer')),
 )
 DEVICES = (


### PR DESCRIPTION
## Description
I've re-ordered a BROWSERS tuple in user_sessions/templatetags/user_sessions.py and renamed the Opera browser in the tuple, that is supposed to be recognizable out of a user agent. Template filter `device` have been trying to recognize Opera browser by name `Opera`, while user agent detects it as `OPR`. Example of user agent: **Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36 OPR/76.0.4017.123**.

## Motivation and Context
It fixes an open [issue #134](https://github.com/jazzband/django-user-sessions/issues/134#issue-896691830)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
