### PR TITLE
Example app no longer functional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,8 @@ forking the repository and sending some pull requests. The package is
 translated into English, Dutch and other languages. Please contribute your own
 language using Transifex_.
 
-Also, have a look at the online `example app`_, hosted by Heroku_. It also
-contains the package `django-two-factor-auth`_, but that application is not a
-dependency for this package. Also have a look at the bundled example templates
-and views to see how you can integrate the application into your project.
+Also have a look at the bundled example templates and views to see how you
+can integrate the application into your project.
 
 Compatible with Django 2.2, 3.0 and 3.1 on Python 3.6, 3.7, 3.8 and 3.9.
 Documentation is available at `readthedocs.org`_.
@@ -151,9 +149,6 @@ This library was written by `Bouke Haarsma`_ and contributors_.
 .. _`readthedocs.org`: https://django-user-sessions.readthedocs.org/
 .. _`installation instructions`:
    https://django-user-sessions.readthedocs.io/en/stable/installation.html
-.. _`example app`: https://example-two-factor-auth.herokuapp.com
-.. _Heroku: https://www.heroku.com
-.. _`django-two-factor-auth`: https://github.com/Bouke/django-two-factor-auth
 .. _installing GeoIP:
    https://docs.djangoproject.com/en/2.0/ref/contrib/gis/geoip2/
 .. _tox: https://testrun.org/tox/latest/


### PR DESCRIPTION
The example app is offline (removed) and shouldn't be referenced anymore. See also: https://github.com/jazzband/help/issues/180#issuecomment-1103480099.