### PR TITLE
Drop Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0', 'main']
         include:
-          - python-version: '3.6'
-            django-version: '3.2'
           - python-version: '3.7'
             django-version: '3.2'
     steps:

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ language using Transifex_.
 Also have a look at the bundled example templates and views to see how you
 can integrate the application into your project.
 
-Compatible with Django 3.2 and 4.0 on Python 3.6, 3.7, 3.8, 3.9 and 3.10.
+Compatible with Django 3.2 and 4.0 on Python 3.7, 3.8, 3.9 and 3.10.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{36,37}-dj32
+    py{37}-dj32
     py{38,39,310}-dj{32,40,main}
     flake8
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
Is is past End Of Life, and some dependencies don't support it any more.

