### PR TITLE
Enable configurable root URL paths

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Installation
    ``'django.contrib.sessions.middleware.SessionMiddleware'`` with
    ``'user_sessions.middleware.SessionMiddleware'``.
 4. Add ``SESSION_ENGINE = 'user_sessions.backends.db'``.
-5. Add ``url(r'', include('user_sessions.urls', 'user_sessions')),`` to your
+5. Add ``url('account/', include('user_sessions.urls', 'user_sessions')),`` to your
    ``urls.py``.
 6. Make sure ``LOGOUT_REDIRECT_URL`` is set to some page to redirect users
    after logging out.

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+development
+-----------
+* Breaking: Tweak URLConf and update instructions on how to include it (#164).
+
 2.0.0
 ----------
 * New: Support for Django 3.2 and 4.0

--- a/example/urls.py
+++ b/example/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
         ),
         name='home',
     ),
-    re_path(r'', include('user_sessions.urls', namespace='user_sessions')),
+    re_path(r'account/', include('user_sessions.urls', namespace='user_sessions')),
     re_path(r'^admin/', admin.site.urls),
 ]
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -18,5 +18,5 @@ urlpatterns = [
     path('', empty),
     path('modify_session/', modify_session),
     path('admin/', admin.site.urls),
-    path('', include('user_sessions.urls', namespace='user_sessions')),
+    path('account/', include('user_sessions.urls', namespace='user_sessions')),
 ]

--- a/user_sessions/urls.py
+++ b/user_sessions/urls.py
@@ -5,12 +5,12 @@ from .views import SessionDeleteOtherView, SessionDeleteView, SessionListView
 app_name = 'user_sessions'
 urlpatterns = [
     path(
-        'account/sessions/',
+        'sessions/',
         view=SessionListView.as_view(),
         name='session_list',
     ),
     path(
-        'account/sessions/other/delete/',
+        'sessions/other/delete/',
         view=SessionDeleteOtherView.as_view(),
         name='session_delete_other',
     ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow this app's URLConf to be parented in more places than just `/account/`.

## Description
<!--- Describe your changes in detail -->

This PR removes the `/account/` prefix from this app's URLConf, allowing developers to choose for themselves what URL prefixes they would like.

To ensure backwards compatibility, I adjusted the root URLConfs in the `tests` project and the `example` project to still use the `/account/` prefix. Furthermore, I also adjusted the documentation to instruct users to do the same:

```python
...
urls = [
    path('account/', include('user_sessions.urls', namespace='user_sessions')),
]
```

Advanced users should hopefully understand that they can adjust that prefix to whatever they'd like, and beginner users will simply mirror the documentation and continue with the previous behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previously behavior isn't necessarily congruous with django-allauth, which uses `/accounts/`, and other users might want different prefixes altogether.

Closes #43 and #47.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated the URLConf in the `tests` project and relied on GHA tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. - N/A
- [ ] All new and existing tests passed.

Assuming that tests for Python 3.7+Django 3.2 pass (currently running), test results for this branch have not changed from test results for `master`.
