### PR TITLE
Simplify

### DIFF
--- a/user_sessions/backends/db.py
+++ b/user_sessions/backends/db.py
@@ -13,6 +13,7 @@ class SessionStore(DBStore):
         self.ip = ip
         self.user_id = None
 
+    # Used by superclass to get self.model, which is used elsewhere
     @classmethod
     def get_model_class(cls):
         # Avoids a circular import and allows importing SessionStore when
@@ -26,6 +27,7 @@ class SessionStore(DBStore):
             self.user_id = value
         super().__setitem__(key, value)
 
+    # Used in DBStore.load()
     def _get_session_from_db(self):
         s = super()._get_session_from_db()
         self.user_id = s.user_id
@@ -38,6 +40,7 @@ class SessionStore(DBStore):
         super().create()
         self._session_cache = {}
 
+    # Used in DBStore.save()
     def create_model_instance(self, data):
         """
         Return a new instance of the session model object, which represents the

--- a/user_sessions/backends/db.py
+++ b/user_sessions/backends/db.py
@@ -1,14 +1,8 @@
-import logging
-
 from django.contrib import auth
-from django.contrib.sessions.backends.base import CreateError, SessionBase
-from django.core.exceptions import SuspiciousOperation
-from django.db import IntegrityError, router, transaction
-from django.utils import timezone
-from django.utils.encoding import force_str
+from django.contrib.sessions.backends.db import SessionStore as DBStore
 
 
-class SessionStore(SessionBase):
+class SessionStore(DBStore):
     """
     Implements database session store.
     """
@@ -19,89 +13,46 @@ class SessionStore(SessionBase):
         self.ip = ip
         self.user_id = None
 
+    @classmethod
+    def get_model_class(cls):
+        # Avoids a circular import and allows importing SessionStore when
+        # user_sessions is not in INSTALLED_APPS
+        from ..models import Session
+
+        return Session
+
     def __setitem__(self, key, value):
         if key == auth.SESSION_KEY:
             self.user_id = value
         super().__setitem__(key, value)
 
-    def load(self):
-        try:
-            s = Session.objects.get(
-                session_key=self.session_key,
-                expire_date__gt=timezone.now()
-            )
-            self.user_id = s.user_id
-            # do not overwrite user_agent/ip, as those might have been updated
-            if self.user_agent != s.user_agent or self.ip != s.ip:
-                self.modified = True
-            return self.decode(s.session_data)
-        except (Session.DoesNotExist, SuspiciousOperation) as e:
-            if isinstance(e, SuspiciousOperation):
-                logger = logging.getLogger('django.security.%s' %
-                                           e.__class__.__name__)
-                logger.warning(force_str(e))
-            self.create()
-            return {}
-
-    def exists(self, session_key):
-        return Session.objects.filter(session_key=session_key).exists()
+    def _get_session_from_db(self):
+        s = super()._get_session_from_db()
+        self.user_id = s.user_id
+        # do not overwrite user_agent/ip, as those might have been updated
+        if self.user_agent != s.user_agent or self.ip != s.ip:
+            self.modified = True
+        return s
 
     def create(self):
-        while True:
-            self._session_key = self._get_new_session_key()
-            try:
-                # Save immediately to ensure we have a unique entry in the
-                # database.
-                self.save(must_create=True)
-            except CreateError:
-                # Key wasn't unique. Try again.
-                continue
-            self.modified = True
-            self._session_cache = {}
-            return
+        super().create()
+        self._session_cache = {}
 
-    def save(self, must_create=False):
+    def create_model_instance(self, data):
         """
-        Saves the current session data to the database. If 'must_create' is
-        True, a database error will be raised if the saving operation doesn't
-        create a *new* entry (as opposed to possibly updating an existing
-        entry).
+        Return a new instance of the session model object, which represents the
+        current session state. Intended to be used for saving the session data
+        to the database.
         """
-        obj = Session(
+        return self.model(
             session_key=self._get_or_create_session_key(),
-            session_data=self.encode(self._get_session(no_load=must_create)),
+            session_data=self.encode(data),
             expire_date=self.get_expiry_date(),
             user_agent=self.user_agent,
             user_id=self.user_id,
             ip=self.ip,
         )
-        using = router.db_for_write(Session, instance=obj)
-        try:
-            with transaction.atomic(using):
-                obj.save(force_insert=must_create, using=using)
-        except IntegrityError as e:
-            if must_create and 'session_key' in str(e):
-                raise CreateError
-            raise
 
     def clear(self):
         super().clear()
         self.user_id = None
-
-    def delete(self, session_key=None):
-        if session_key is None:
-            if self.session_key is None:
-                return
-            session_key = self.session_key
-        try:
-            Session.objects.get(session_key=session_key).delete()
-        except Session.DoesNotExist:
-            pass
-
-    @classmethod
-    def clear_expired(cls):
-        Session.objects.filter(expire_date__lt=timezone.now()).delete()
-
-
-# At bottom to avoid circular import
-from ..models import Session  # noqa: E402 isort:skip

--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -1,68 +1,17 @@
-import time
-
 from django.conf import settings
-from django.utils.cache import patch_vary_headers
-from django.utils.http import http_date
-
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    class MiddlewareMixin:
-        pass
+from django.contrib.sessions.middleware import (
+    SessionMiddleware as DjangoSessionMiddleware,
+)
 
 
-class SessionMiddleware(MiddlewareMixin):
+class SessionMiddleware(DjangoSessionMiddleware):
     """
     Middleware that provides ip and user_agent to the session store.
     """
     def process_request(self, request):
-        engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
-        request.session = engine.SessionStore(
+        request.session = self.SessionStore(
             ip=request.META.get('REMOTE_ADDR', ''),
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )
-
-    def process_response(self, request, response):
-        """
-        If request.session was modified, or if the configuration is to save the
-        session every time, save the changes and set a session cookie.
-        """
-        try:
-            accessed = request.session.accessed
-            modified = request.session.modified
-        except AttributeError:
-            pass
-        else:
-            if accessed:
-                patch_vary_headers(response, ('Cookie',))
-            if modified or settings.SESSION_SAVE_EVERY_REQUEST:
-                if request.session.get_expire_at_browser_close():
-                    max_age = None
-                    expires = None
-                else:
-                    max_age = request.session.get_expiry_age()
-                    expires_time = time.time() + max_age
-                    expires = http_date(expires_time)
-                # Save the session data and refresh the client cookie.
-                # Skip session save for 500 responses, refs #3881.
-                if response.status_code != 500:
-                    request.session.save()
-                    response.set_cookie(
-                        settings.SESSION_COOKIE_NAME,
-                        request.session.session_key,
-                        max_age=max_age,
-                        expires=expires,
-                        domain=settings.SESSION_COOKIE_DOMAIN,
-                        path=settings.SESSION_COOKIE_PATH,
-                        secure=settings.SESSION_COOKIE_SECURE or None,
-                        httponly=settings.SESSION_COOKIE_HTTPONLY or None,
-                        samesite=settings.SESSION_COOKIE_SAMESITE,
-                    )
-        return response

--- a/user_sessions/models.py
+++ b/user_sessions/models.py
@@ -40,6 +40,12 @@ class Session(models.Model):
                                    primary_key=True)
     session_data = models.TextField(_('session data'))
     expire_date = models.DateTimeField(_('expiry date'), db_index=True)
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
+                             null=True, on_delete=models.CASCADE)
+    user_agent = models.CharField(null=True, blank=True, max_length=200)
+    last_activity = models.DateTimeField(auto_now=True)
+    ip = models.GenericIPAddressField(null=True, blank=True, verbose_name='IP')
+
     objects = SessionManager()
 
     class Meta:
@@ -48,9 +54,3 @@ class Session(models.Model):
 
     def get_decoded(self):
         return SessionStore(None, None).decode(self.session_data)
-
-    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
-                             null=True, on_delete=models.CASCADE)
-    user_agent = models.CharField(null=True, blank=True, max_length=200)
-    last_activity = models.DateTimeField(auto_now=True)
-    ip = models.GenericIPAddressField(null=True, blank=True, verbose_name='IP')

--- a/user_sessions/models.py
+++ b/user_sessions/models.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from .backends.db import SessionStore
+
 
 class SessionManager(models.Manager):
     use_in_migrations = True
@@ -52,7 +54,3 @@ class Session(models.Model):
     user_agent = models.CharField(null=True, blank=True, max_length=200)
     last_activity = models.DateTimeField(auto_now=True)
     ip = models.GenericIPAddressField(null=True, blank=True, verbose_name='IP')
-
-
-# At bottom to avoid circular import
-from .backends.db import SessionStore  # noqa: E402 isort:skip

--- a/user_sessions/urls.py
+++ b/user_sessions/urls.py
@@ -1,8 +1,6 @@
-from django.urls import path, re_path
+from django.urls import path
 
-from user_sessions.views import SessionDeleteOtherView
-
-from .views import SessionDeleteView, SessionListView
+from .views import SessionDeleteOtherView, SessionDeleteView, SessionListView
 
 app_name = 'user_sessions'
 urlpatterns = [
@@ -16,8 +14,8 @@ urlpatterns = [
         view=SessionDeleteOtherView.as_view(),
         name='session_delete_other',
     ),
-    re_path(
-        r'^account/sessions/(?P<pk>\w+)/delete/$',
+    path(
+        'account/sessions/<str:pk>/delete/',
         view=SessionDeleteView.as_view(),
         name='session_delete',
     ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Using some of the code from Django, we can greatly simplify and even remove some of our code.

## Description
<!--- Describe your changes in detail -->

* I adjusted our middleware to inherit from Django's so we don't have to duplicate any of that code
  - Django imports the session engine only once, instead of on each request - this also simplifies our module imports
  - We don't have to define our own `process_response` at all, since it wasn't materially different from Django's
* I tweaked our session backend to inherit from Django's, and tweaked it to use some of the methods defined in the superclass
  - Redefine `get_model_class` to import and use our `Session` model, which allows other methods (including ones from the superclass) to use [`self.model`](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L26)
  - Use `self.model` instead of our own `Session` model directly
  - Remove our own `exists` method entirely (which will use [Django's](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L45))
  - Define and override `_get_session_from_db`, so we can remove the [`load` method](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L41)
  - Override and use [Django's `create` method](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L48)
  - Define and [override `create_model_instance`](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L61) so we don't have to define our own [`save` method](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L73)
  - Remove our own copied version of the [`delete`](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L98) and [`clear_expired`](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/contrib/sessions/backends/db.py#L109) methods

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We duplicated a lot of code from `django.contrib.sessions`. The less code we duplicate, the less code we have to maintain ourselves.

This might also make it easier to add a `cached_db` backend similar to Django's.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Normal tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Reverse-compatible code improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
