### PR TITLE
Drop unsupported django 4.0, 4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12-dev']
-        django-version: ['3.2', '4.0', '4.1', '4.2', 'main']
+        django-version: ['3.2', '4.2', 'main']
         include:
           - python-version: '3.7'
             django-version: '3.2'

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ language using Transifex_.
 Also have a look at the bundled example templates and views to see how you
 can integrate the application into your project.
 
-Compatible with Django 3.2 and 4.0 on Python 3.7 to 3.11.
+Compatible with Django 3.2 and 4.2 on Python 3.7 to 3.11.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ minversion = 1.8
 envlist =
     ; https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django
     py{37}-dj32
-    py{38,39,310}-dj{32,40,41}
-    py{311}-dj41
+    py{38,39,310}-dj32
     py{311,312}-dj{42,main}
 
 [gh-actions]
@@ -20,8 +19,6 @@ python =
 [gh-actions:env]
 DJANGO =
     3.2: dj32
-    4.0: dj40
-    4.1: dj41
     4.2: dj42
     main: djmain
 
@@ -34,8 +31,6 @@ commands =
 deps =
     coverage
     dj32: Django>=3.2,<4.0
-    dj40: Django>=4.0,<4.1
-    dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     geoip2


### PR DESCRIPTION
## Description
Solves https://github.com/jazzband/django-user-sessions/issues/169

I didn't test it locally, I hope gh runner would say everything is okey.

I don't know if I should fix [pypi classifier](https://github.com/jazzband/django-user-sessions/blob/dab2bdf90bb50344c446dc48db3bc49a2af7037a/pyproject.toml#L20) from `"Framework :: Django :: 4.0"` to `"Framework :: Django :: 4.2"`. I guess it's related to pypi index and SEO so I would not do it without real reason.

---

I'm also thinking to remove py37 runtime (https://endoflife.date/python) but I guess it's a lot of work. If you know it's easier than I think (just removing some lines in gh flows and tox tests), I would do it in this PR.