### PR TITLE
Added the "UserSessionsConfig" class

### DIFF
--- a/user_sessions/apps.py
+++ b/user_sessions/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class UserSessionsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'user_sessions'
+    verbose_name = 'User Sessions'


### PR DESCRIPTION
## Description
Since the class includes `verbose_name = 'User Sessions'`, this makes it so that the app appears in the admin as "User Sessions" instead of "User_Sessions".

## Motivation and Context
Django apps' verbose names are meant to be read by humans (e.g. "Authentication and Authorization", not "Authentication_and_Authorization").

## How Has This Been Tested?
I looked in the admin.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. ← I don't know the answer. I assume GitHub will tell me.