### PR TITLE
Add support for Django 5.0 and 5.1, along with Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,27 +10,32 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12-dev']
-        django-version: ['3.2', '4.2', 'main']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        django-version: ['3.2', '4.2', '5.0', '5.1', 'main']
         exclude:
           - python-version: '3.11'
             django-version: '3.2'
-          - python-version: '3.12-dev'
+          - python-version: '3.12'
+            django-version: '3.2'
+          - python-version: '3.13'
             django-version: '3.2'
 
-          - python-version: '3.11'
-            django-version: '4.0'
-          - python-version: '3.12-dev'
-            django-version: '4.0'
+          - python-version: '3.13'
+            django-version: '4.2'
 
-          - python-version: '3.12-dev'
-            django-version: '4.1'
+          - python-version: '3.8'
+            django-version: '5.0'
+          - python-version: '3.9'
+            django-version: '5.0'
+
+          - python-version: '3.8'
+            django-version: '5.1'
+          - python-version: '3.9'
+            django-version: '5.1'
 
           - python-version: '3.8'
             django-version: 'main'
           - python-version: '3.9'
-            django-version: 'main'
-          - python-version: '3.10'
             django-version: 'main'
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
             django-version: '5.0'
           - python-version: '3.9'
             django-version: '5.0'
+          - python-version: '3.13'
+            django-version: '5.0'
 
           - python-version: '3.8'
             django-version: '5.1'

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ language using Transifex_.
 Also have a look at the bundled example templates and views to see how you
 can integrate the application into your project.
 
-Compatible with Django 3.2 and 4.2 on Python 3.8 to 3.11.
+Compatible with Django 3.2, 4.2, 5.0 and 5.1 on Python 3.8 to 3.13.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
   "Framework :: Django",
   "Framework :: Django :: 3.2",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
@@ -27,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Security",
 ]
 dependencies = [

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -1,5 +1,6 @@
 from unittest import skipUnless
 
+import django
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -37,12 +38,22 @@ class LocationTemplateFilterTest(TestCase):
         self.assertEqual('San Diego', city('44.55.66.77'))
 
     @skipUnless(geoip, geoip_msg)
-    def test_country(self):
+    @skipUnless(django.VERSION < (5, 1), "Django 5.1 looks up country using city DB")
+    def test_country_pre_51(self):
         self.assertEqual('United States', country('8.8.8.8'))
 
     @skipUnless(geoip, geoip_msg)
-    def test_locations(self):
+    @skipUnless(django.VERSION >= (5, 1), "Django 5.1 looks up country using city DB")
+    def test_country_51_and_above(self):
+        self.assertEqual('United States', country('44.55.66.77'))
+
+    @skipUnless(geoip, geoip_msg)
+    @skipUnless(django.VERSION < (5, 1), "Django 5.1 looks up country using city DB")
+    def test_locations_country_only_pre_51(self):
         self.assertEqual('United States', location('8.8.8.8'))
+
+    @skipUnless(geoip, geoip_msg)
+    def test_location_in_city(self):
         self.assertEqual('San Diego, United States', location('44.55.66.77'))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    ; https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django
-    py{37}-dj32
+    ; https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
     py{38,39,310}-dj32
     py{311,312}-dj{42,main}
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ minversion = 1.8
 envlist =
     ; https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
     py{38,39,310}-dj32
-    py{311,312}-dj{42,main}
+    py{38,39,310,311,312}-dj42
+    py{310,311,312}-dj50
+    py{310,311,312,313}-dj{51,main}
 
 [gh-actions]
 python =
@@ -13,11 +15,14 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
     3.2: dj32
     4.2: dj42
+    5.0: dj50
+    5.1: dj51
     main: djmain
 
 [testenv]
@@ -30,6 +35,8 @@ deps =
     coverage
     dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<4.3
+    dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     geoip2
 ignore_outcome =


### PR DESCRIPTION
## Description
Update CI config to run tests against 5.0 and 5.1 + Python 3.13. Declare official support in Trove classifiers and update docs in readme.

## Motivation and Context
Keep up to date with Django ecosystem.

## How Has This Been Tested?
Existing test suite, updated dependencies in tox file.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
