### PR TITLE
Fix release Action reference (as suggested by author)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload packages to Jazzband
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: jazzband
           password: ${{ secrets.JAZZBAND_RELEASE_KEY }}


### PR DESCRIPTION
Fixes a reference in the release workflow.

## Description

The PyPI Publish Action emits a warning when gh-action-pypi-publish is used with `master` as a reference. The authors suggest to update to `release/v1`.

## Motivation and Context

Background reading:

- jazzband/django-analytical#241 (comment)
- [gh-action-pypi-publish README](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#-master-branch-sunset-) (master branch sunset)

## Screenshots

Example: (taken from django-analytical)

<img width="1500" height="1276" alt="image" src="https://github.com/user-attachments/assets/6a6c88e6-d061-454a-9fa8-3b05bf8c28dd" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
