### PR TITLE
Support for Django 5.2 / 6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U build twine
 
       - name: Build package
         run: |
-          python setup.py --version
-          python setup.py sdist --format=gztar bdist_wheel
+          python -m build
           twine check dist/*
 
       - name: Upload packages to Jazzband

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,27 +10,17 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12-dev']
-        django-version: ['3.2', '4.2', 'main']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        django-version: ['5.2', '6.0', 'main']
         exclude:
-          - python-version: '3.11'
-            django-version: '3.2'
-          - python-version: '3.12-dev'
-            django-version: '3.2'
-
-          - python-version: '3.11'
-            django-version: '4.0'
-          - python-version: '3.12-dev'
-            django-version: '4.0'
-
-          - python-version: '3.12-dev'
-            django-version: '4.1'
-
-          - python-version: '3.8'
-            django-version: 'main'
-          - python-version: '3.9'
-            django-version: 'main'
           - python-version: '3.10'
+            django-version: '6.0'
+          - python-version: '3.11'
+            django-version: '6.0'
+
+          - python-version: '3.10'
+            django-version: 'main'
+          - python-version: '3.11'
             django-version: 'main'
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ruff:
 
 example:
 	DJANGO_SETTINGS_MODULE=example.settings PYTHONPATH=. \
-		django-admin.py runserver
+		django-admin runserver
 
 check:
 	DJANGO_SETTINGS_MODULE=example.settings PYTHONPATH=. \
@@ -19,11 +19,11 @@ generate-mmdb-fixtures:
 
 test: generate-mmdb-fixtures
 	DJANGO_SETTINGS_MODULE=tests.settings PYTHONPATH=. \
-		django-admin.py test ${TARGET}
+		django-admin test ${TARGET}
 
 migrations:
 	DJANGO_SETTINGS_MODULE=tests.settings PYTHONPATH=. \
-		django-admin.py makemigrations user_sessions
+		django-admin makemigrations user_sessions
 
 coverage:
 	coverage erase
@@ -34,8 +34,8 @@ coverage:
 
 tx-pull:
 	tx pull -a
-	cd user_sessions; django-admin.py compilemessages
+	cd user_sessions; django-admin compilemessages
 
 tx-push:
-	cd user_sessions; django-admin.py makemessages -l en
+	cd user_sessions; django-admin makemessages -l en
 	tx push -s

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ language using Transifex_.
 Also have a look at the bundled example templates and views to see how you
 can integrate the application into your project.
 
-Compatible with Django 3.2 and 4.2 on Python 3.8 to 3.11.
+Compatible with Django 5.2 and 6.0 on Python 3.10 to 3.13.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+3.0.0
+----------
+* New: Support for Django 5.2 and 6.0.
+* New: Support for Python 3.13.
+* Dropped support for Django 3.2 and 4.2 (both end-of-life).
+* Dropped support for Python 3.7, 3.8 and 3.9.
+
 2.0.0
 ----------
 * New: Support for Django 3.2 and 4.0

--- a/example/settings.py
+++ b/example/settings.py
@@ -40,6 +40,7 @@ TEMPLATES = [
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
+                'django.template.context_processors.request',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,29 +8,28 @@ authors = [
 ]
 description = "Django sessions with a foreign key to the user"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["django", "sessions"]
 license = {text = "MIT"}
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Security",
 ]
 dependencies = [
-    "Django>=3.2",
+    "Django>=5.2",
 ]
 dynamic = ["version"]
 

--- a/tests/generate_mmdb.pl
+++ b/tests/generate_mmdb.pl
@@ -50,6 +50,16 @@ $city_tree->insert_network(
     },
 );
 
+# Django >= 5.1 GeoIP2 queries the city database (when configured) for
+# country lookups too, so the city db needs this country-only record.
+$city_tree->insert_network(
+    '8.8.8.8/32',
+    {
+        continent => { code => 'NA', names => {en => 'North America'} },
+        country   => { iso_code => 'US', names => {en => 'United States'} },
+    },
+);
+
 my $outfile = ($ENV{'DATA_DIR'} || '/data/') . ($ENV{'CITY_FILENAME'} || 'test_city.mmdb');
 open my $fh, '>:raw', $outfile;
 $city_tree->write_tree($fh);

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,3 +40,25 @@ class MigratesessionsCommandTest(TransactionTestCase):
             self.assertEqual(new_sessions[0].ip, '127.0.0.1')
         finally:
             call_command('migrate', 'sessions', 'zero')
+
+    @modify_settings(INSTALLED_APPS={'append': 'django.contrib.sessions'})
+    def test_migrate_anonymous_and_idempotent(self):
+        from django.contrib.sessions.backends.db import (
+            SessionStore as DjangoSessionStore,
+        )
+        try:
+            call_command('migrate', 'sessions')
+            call_command('clearsessions')
+            # Anonymous session without _auth_user_id migrates with user=None
+            session = DjangoSessionStore()
+            session['foo'] = 'bar'
+            session.save()
+            call_command('migratesessions')
+            new_sessions = list(Session.objects.all())
+            self.assertEqual(len(new_sessions), 1)
+            self.assertIsNone(new_sessions[0].user)
+            # Running again skips the already-migrated session
+            call_command('migratesessions')
+            self.assertEqual(Session.objects.count(), 1)
+        finally:
+            call_command('migrate', 'sessions', 'zero')

--- a/tests/test_sessionstore.py
+++ b/tests/test_sessionstore.py
@@ -145,3 +145,9 @@ class AsyncSessionStoreTest(TestCase):
 
         session = await Session.objects.aget(pk=self.store.session_key)
         self.assertEqual(session.user_id, 1)
+
+    async def test_aset_non_session_key(self):
+        # A non-auth key must not be treated as the user id
+        await self.store.aset('foo', 'bar')
+        self.assertIsNone(self.store.user_id)
+        self.assertEqual(await self.store.aget('foo'), 'bar')

--- a/tests/test_sessionstore.py
+++ b/tests/test_sessionstore.py
@@ -97,3 +97,51 @@ class SessionStoreTest(TestCase):
 
         session = Session.objects.get(pk=self.store.session_key)
         self.assertEqual(session.user_id, None)
+
+
+class AsyncSessionStoreTest(TestCase):
+    def setUp(self):
+        self.store = SessionStore(user_agent='Python/2.7', ip='127.0.0.1')
+        User.objects.create_user('bouke', '', 'secret', id=1)
+
+    async def test_asave(self):
+        # auth.alogin() writes the session key via aset()
+        await self.store.aset(auth.SESSION_KEY, 1)
+        await self.store.asave()
+
+        session = await Session.objects.aget(pk=self.store.session_key)
+        self.assertEqual(session.user_agent, 'Python/2.7')
+        self.assertEqual(session.ip, '127.0.0.1')
+        self.assertEqual(session.user_id, 1)
+        self.assertAlmostEqual(now(), session.last_activity,
+                               delta=timedelta(seconds=5))
+
+    async def test_aload_unmodified(self):
+        await self.store.aset(auth.SESSION_KEY, 1)
+        await self.store.asave()
+        store2 = SessionStore(session_key=self.store.session_key,
+                              user_agent='Python/2.7', ip='127.0.0.1')
+        await store2.aload()
+        self.assertEqual(store2.user_agent, 'Python/2.7')
+        self.assertEqual(store2.ip, '127.0.0.1')
+        self.assertEqual(store2.user_id, 1)
+        self.assertEqual(store2.modified, False)
+
+    async def test_aload_modified(self):
+        await self.store.aset(auth.SESSION_KEY, 1)
+        await self.store.asave()
+        store2 = SessionStore(session_key=self.store.session_key,
+                              user_agent='Python/3.3', ip='8.8.8.8')
+        await store2.aload()
+        self.assertEqual(store2.user_agent, 'Python/3.3')
+        self.assertEqual(store2.ip, '8.8.8.8')
+        self.assertEqual(store2.user_id, 1)
+        self.assertEqual(store2.modified, True)
+
+    async def test_acycle_key_retains_user(self):
+        await self.store.aset(auth.SESSION_KEY, 1)
+        await self.store.acycle_key()
+        await self.store.asave()
+
+        session = await Session.objects.aget(pk=self.store.session_key)
+        self.assertEqual(session.user_id, 1)

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -11,15 +11,10 @@ from user_sessions.templatetags.user_sessions import (
 try:
     from django.contrib.gis.geoip2 import GeoIP2
     geoip = GeoIP2()
-    geoip_msg = None
+    geoip_msg = ''
 except Exception as error_geoip2:  # pragma: no cover
-    try:
-        from django.contrib.gis.geoip import GeoIP
-        geoip = GeoIP()
-        geoip_msg = None
-    except Exception as error_geoip:
-        geoip = None
-        geoip_msg = str(error_geoip2) + " and " + str(error_geoip)
+    geoip = None
+    geoip_msg = str(error_geoip2)
 
 
 class LocationTemplateFilterTest(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -2,23 +2,22 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    ; https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django
-    py{37}-dj32
-    py{38,39,310}-dj32
-    py{311,312}-dj{42,main}
+    ; https://docs.djangoproject.com/en/5.2/faq/install/#what-python-version-can-i-use-with-django
+    py{310,311,312,313}-dj52
+    py{312,313}-dj60
+    py{312,313}-djmain
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
-    4.2: dj42
+    5.2: dj52
+    6.0: dj60
     main: djmain
 
 [testenv]
@@ -29,8 +28,8 @@ commands =
     coverage xml
 deps =
     coverage
-    dj32: Django>=3.2,<4.0
-    dj42: Django>=4.2,<4.3
+    dj52: Django>=5.2,<5.3
+    dj60: Django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     geoip2
 ignore_outcome =

--- a/user_sessions/__init__.py
+++ b/user_sessions/__init__.py
@@ -1,12 +1,3 @@
-try:
-    from importlib.metadata import version
-except ImportError:
-    from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version
 
-    try:
-        __version__ = get_distribution("django-user-sessions").version
-    except DistributionNotFound:
-        # package is not installed
-        __version__ = None
-else:
-    __version__ = version("django-user-sessions")
+__version__ = version("django-user-sessions")

--- a/user_sessions/backends/db.py
+++ b/user_sessions/backends/db.py
@@ -27,6 +27,12 @@ class SessionStore(DBStore):
             self.user_id = value
         super().__setitem__(key, value)
 
+    # Used by auth.alogin() on Django >= 5.1, which bypasses __setitem__()
+    async def aset(self, key, value):
+        if key == auth.SESSION_KEY:
+            self.user_id = value
+        await super().aset(key, value)
+
     # Used in DBStore.load()
     def _get_session_from_db(self):
         s = super()._get_session_from_db()
@@ -36,8 +42,21 @@ class SessionStore(DBStore):
             self.modified = True
         return s
 
+    # Used in DBStore.aload() on Django >= 5.1
+    async def _aget_session_from_db(self):
+        s = await super()._aget_session_from_db()
+        self.user_id = s.user_id
+        # do not overwrite user_agent/ip, as those might have been updated
+        if self.user_agent != s.user_agent or self.ip != s.ip:
+            self.modified = True
+        return s
+
     def create(self):
         super().create()
+        self._session_cache = {}
+
+    async def acreate(self):
+        await super().acreate()
         self._session_cache = {}
 
     # Used in DBStore.save()
@@ -51,6 +70,18 @@ class SessionStore(DBStore):
             session_key=self._get_or_create_session_key(),
             session_data=self.encode(data),
             expire_date=self.get_expiry_date(),
+            user_agent=self.user_agent,
+            user_id=self.user_id,
+            ip=self.ip,
+        )
+
+    # Used in DBStore.asave() on Django >= 5.1
+    async def acreate_model_instance(self, data):
+        """See create_model_instance()."""
+        return self.model(
+            session_key=await self._aget_or_create_session_key(),
+            session_data=self.encode(data),
+            expire_date=await self.aget_expiry_date(),
             user_agent=self.user_agent,
             user_id=self.user_id,
             ip=self.ip,

--- a/user_sessions/management/commands/migratesessions.py
+++ b/user_sessions/management/commands/migratesessions.py
@@ -15,7 +15,7 @@ def get_model_class(full_model_name):
         package = importlib.import_module(old_model_package)
         return getattr(package, old_model_class_name)
     except RuntimeError as e:
-        if 'INSTALLED_APPS' in e.message:
+        if 'INSTALLED_APPS' in str(e):
             raise RuntimeError(
                 "To run this command, temporarily append '{model}' to settings.INSTALLED_APPS"
                 .format(model=old_model_package.rsplit('.models')[0]))


### PR DESCRIPTION
## Description
Add Django 5.2/6.0 support, drop EOL Django and Python versions

Closes #169, #188 

## Motivation and Context
The package currently supports Django 3.2 and 4.2, both of which have reached
end of extended support (April 2024 and April 2026 respectively, per the
[supported versions table](https://www.djangoproject.com/download/#supported-versions)).
Meanwhile Django 5.1+ introduced changes that this package must adapt to —
one of which causes silent data loss in async views.

## How Has This Been Tested?
Python 3.10–3.13 × Django 5.2 / 6.0 / main, with 3.10/3.11 excluded for
6.0+ (Django 6.0 [requires Python 3.12+](https://docs.djangoproject.com/en/6.0/releases/6.0/#python-compatibility)).
Full suite verified locally on Django 5.2 (Python 3.11) and Django 6.0
(Python 3.13), including a `-W error::DeprecationWarning` run — no
deprecation warnings on either.


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Changes

### Async session API support (bug fix)

Django 5.1 [added an async API to all session backends](https://docs.djangoproject.com/en/5.2/releases/5.1/#django-contrib-sessions)
(`aget()`, `asave()`, `aload()`, …), and Django 5.0 added
[`auth.alogin()` and friends](https://docs.djangoproject.com/en/5.2/releases/5.0/#django-contrib-auth).
Django's async `DBStore` methods do not delegate to their sync equivalents, so
this package's sync-only overrides were bypassed entirely in async code paths:
sessions saved via `alogin()` or any async view were written with `user`,
`user_agent` and `ip` all `NULL` — silently, since the model fields are
nullable. This defeats the package's core purpose.

Fixed by mirroring the four sync overrides with async counterparts in
`user_sessions.backends.db.SessionStore`:

- `aset()` — captures `user_id`; note `alogin()` writes the session key via
  `aset()`, bypassing `__setitem__`
- `_aget_session_from_db()` — restores `user_id`, flags `modified` on
  user-agent/IP change
- `acreate()` — resets the session cache
- `acreate_model_instance()` — persists `user_agent`, `user_id` and `ip`

Covered by new tests exercising the same call sequence `alogin()` uses.

### GeoIP2 test fixtures

Django 5.1 [changed `GeoIP2` to open a single database](https://docs.djangoproject.com/en/5.2/releases/5.1/#backwards-incompatible-5-1),
preferring the city database when available, so country lookups now hit the
city db. The city test fixture gained a country-only record for `8.8.8.8`;
the fixture generation stays compatible with the pre-5.1 lookup path.

### Dropped versions (breaking)

- Django 3.2 and 4.2 (end of extended support: April 2024 / April 2026)
- Python 3.7–3.9 (Django 5.2 [supports Python 3.10–3.13](https://docs.djangoproject.com/en/5.2/releases/5.2/#python-compatibility))

Dead code removed accordingly: the `pkg_resources` version fallback, the
`django.contrib.gis.geoip` test fallback (API removed in Django 3.0), and a
Django version guard in tests.

### Tooling fixes

- The release workflow still invoked `setup.py`, which no longer exists since
  the move to `pyproject.toml`; it now builds with `python -m build`
  (verified: artifacts build and pass `twine check`)
- `migratesessions` used the Python 2-only `e.message` attribute, raising
  `AttributeError` on any Python 3
- The Makefile referenced `django-admin.py`,
  [removed in Django 4.0](https://docs.djangoproject.com/en/5.2/releases/4.0/#features-removed-in-4-0)
- The example app lacked the `request` context processor required by the
  admin sidebar

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
